### PR TITLE
Add FINRISK combined risk sum calculation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,0 +1,40 @@
+const clampProbability = (value) => {
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+
+  if (value < 0) {
+    return 0;
+  }
+
+  if (value > 1) {
+    return 1;
+  }
+
+  return value;
+};
+
+const riskModels = {
+  finrisk: {
+    /**
+     * Calculates the combined cardiovascular risk for FINRISK inputs.
+     * @param {Object} params
+     * @param {number} params.coronaryRisk - Coronary heart disease risk (0-1).
+     * @param {number} params.strokeRisk - Stroke risk (0-1).
+     * @returns {number} Combined risk probability clamped between 0 and 1.
+     */
+    calculate({ coronaryRisk = 0, strokeRisk = 0 } = {}) {
+      const coronary = Number.isFinite(coronaryRisk) ? coronaryRisk : 0;
+      const stroke = Number.isFinite(strokeRisk) ? strokeRisk : 0;
+
+      const combinedRisk = coronary + stroke;
+
+      return clampProbability(combinedRisk);
+    },
+  },
+};
+
+module.exports = {
+  clampProbability,
+  riskModels,
+};


### PR DESCRIPTION
## Summary
- add a FINRISK risk calculator implementation that sums coronary and stroke risk contributions
- ensure the combined probability is clamped to the 0–100% range

## Testing
- node - <<'NODE'
const { riskModels } = require('./script.js');

const cases = [
  { coronaryRisk: 0.1, strokeRisk: 0.05 },
  { coronaryRisk: 0.35, strokeRisk: 0.8 },
  { coronaryRisk: 0.03, strokeRisk: 0.04 },
];

for (const input of cases) {
  const value = riskModels.finrisk.calculate(input);
  console.log(input, '=>', value);
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68de1dc6f490832a8632c88b41e5bf49