### PR TITLE
Update PREVENT risk equation

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,11 +78,23 @@
             <option value="yes">Yes</option>
           </select>
 
-          <label for="ckd" class="prevent-only">Chronic kidney disease</label>
-          <select id="ckd" name="ckd" class="prevent-only">
+          <label for="statin" class="prevent-only">On statin therapy</label>
+          <select id="statin" name="statin" class="prevent-only">
             <option value="no">No</option>
             <option value="yes">Yes</option>
           </select>
+
+          <label for="egfr" class="prevent-only">Estimated GFR (mL/min/1.73m²)</label>
+          <input
+            type="number"
+            id="egfr"
+            name="egfr"
+            class="prevent-only"
+            min="15"
+            max="150"
+            step="1"
+            value="90"
+          />
         </div>
 
         <div class="actions">
@@ -96,8 +108,30 @@
       <div class="result-summary">
         <h2>Estimated 10-year cardiovascular risk</h2>
         <p id="baseline-risk">Baseline risk: <strong>--</strong></p>
-        <ul id="treatment-list" class="treatment-list"></ul>
       </div>
+
+      <div class="chart-controls">
+        <h3>Select treatments to display</h3>
+        <div
+          id="treatment-checkboxes"
+          class="checkbox-group"
+          role="group"
+          aria-label="Treatment options to include in chart"
+        ></div>
+      </div>
+
+      <details id="treatment-details" class="treatment-summary">
+        <summary id="treatment-summary">
+          <span id="treatment-summary-label">Numerical treatment estimates</span>
+          <span id="treatment-summary-baseline" class="summary-baseline"></span>
+        </summary>
+        <div class="treatment-summary-content">
+          <p id="treatment-summary-note" class="treatment-summary-note">
+            Calculate risk to view estimated benefits for each treatment strategy.
+          </p>
+          <ul id="treatment-list" class="treatment-list"></ul>
+        </div>
+      </details>
 
       <div class="chart-container">
         <canvas id="risk-chart" aria-label="Risk reduction chart" role="img"></canvas>

--- a/styles.css
+++ b/styles.css
@@ -161,6 +161,108 @@ button[type='submit']:hover {
   padding: 0.75rem 1rem;
 }
 
+.treatment-summary {
+  border: 1px solid rgba(12, 143, 214, 0.12);
+  border-radius: 1rem;
+  background: rgba(12, 143, 214, 0.06);
+  padding: 0.25rem 0.75rem;
+}
+
+.treatment-summary summary {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--accent-dark);
+  list-style: none;
+  padding: 0.5rem 0.25rem;
+  border-radius: 0.75rem;
+}
+
+.treatment-summary summary::-webkit-details-marker {
+  display: none;
+}
+
+.treatment-summary summary::before {
+  content: '▾';
+  transition: transform 0.2s ease;
+  display: inline-flex;
+  transform: rotate(-90deg);
+  font-size: 0.85rem;
+  color: var(--accent);
+}
+
+.treatment-summary[open] summary::before {
+  transform: rotate(0deg);
+}
+
+.treatment-summary summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.summary-baseline {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--muted);
+  margin-left: auto;
+}
+
+.treatment-summary-content {
+  margin-top: 0.75rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.treatment-summary-note {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(81, 96, 112, 0.85);
+}
+
+.treatment-list .empty-state {
+  justify-content: flex-start;
+  color: rgba(81, 96, 112, 0.85);
+  font-style: italic;
+}
+
+.chart-controls {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.chart-controls h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--muted);
+}
+
+.checkbox-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+}
+
+.checkbox-option {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(12, 143, 214, 0.08);
+  border-radius: 999px;
+  padding: 0.4rem 0.75rem;
+}
+
+.checkbox-option input[type='checkbox'] {
+  width: auto;
+  margin: 0;
+}
+
+.checkbox-option label {
+  font-weight: 500;
+  color: var(--text);
+}
+
 .chart-container {
   position: relative;
   height: 360px;


### PR DESCRIPTION
## Summary
- limit the treatment comparison chart to a 0-50% y-axis range and keep colour assignments aligned
- add a combined one blood pressure medication plus statin strategy alongside the existing options
- allow users to toggle which treatment strategies appear in the chart via new checkboxes
- surface numerical treatment benefit estimates in a collapsible summary above the chart and show the current baseline risk there
- draw percentage labels above each treatment bar so the visual comparison also exposes the exact estimated risk
- replace the PREVENT risk model with the published logistic equation, including form inputs for statin therapy and eGFR so the calculator uses the correct variables

## Testing
- manual verification via Playwright-driven browser session


------
https://chatgpt.com/codex/tasks/task_e_68de2d9d52bc832a9d475df1fccb72bb