### PR TITLE
Show numerical treatment estimates open by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
         ></div>
       </div>
 
-      <details id="treatment-details" class="treatment-summary">
+      <details id="treatment-details" class="treatment-summary" open>
         <summary id="treatment-summary">
           <span id="treatment-summary-label">Numerical treatment estimates</span>
           <span id="treatment-summary-baseline" class="summary-baseline"></span>


### PR DESCRIPTION
Add the `open` attribute to the <details> element so the numerical treatment table is visible on page load. Users can still collapse and expand it by clicking the summary heading.

https://claude.ai/code/session_01RC2jtTqGhdxsZP9cEEr4jk